### PR TITLE
mz: Fix accidental assignment in conditional statement

### DIFF
--- a/staging/mausezahn.c
+++ b/staging/mausezahn.c
@@ -590,8 +590,8 @@ int getopts (int argc, char *argv[])
 			}
 			break;
 		 case '?':
-			if ((optopt == 'a') || (optopt == 'b') || (optopt = 'c') ||
-			    (optopt == 'd') || (optopt == 'f') || (optopt = 'p') ||
+			if ((optopt == 'a') || (optopt == 'b') || (optopt == 'c') ||
+			    (optopt == 'd') || (optopt == 'f') || (optopt == 'p') ||
 			    (optopt == 't') || (optopt == 'm'))
 				fprintf (stderr, " mz/getopts: Option -%c requires an argument.\n", optopt);
 			else if (isprint (optopt))


### PR DESCRIPTION
Corrects the accidental assignment of _c_ to 'c' or 'p' due to a missing equals sign. This enables the proper display of the missing argument error message for all relevant options.

Signed-off-by: Michael R Torres <mic.ric.tor@gmail.com>